### PR TITLE
feat(TFD-9078): Keep the current classloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Jcrfsuite can be dropped into any Java web applications and run without problem 
 <dependency>
   <groupId>com.github.vinhkhuc</groupId>
   <artifactId>jcrfsuite</artifactId>
-  <version>0.6.1</version>
+  <version>0.6.1-TLND</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.github.vinhkhuc</groupId>
 	<artifactId>jcrfsuite</artifactId>
-	<version>0.6.1</version>
+	<version>0.6.1-TLND</version>
 	<name>Crfsuite for Java</name>
 	<description>
 		Jcrfsuite is a Java interface for crfsuite, a fast implementation of Conditional Random Fields, 
@@ -192,5 +192,5 @@
 			<version>1.3</version>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
+    </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -146,20 +146,6 @@
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-gpg-plugin</artifactId>
-				<version>1.5</version>
-				<executions>
-					<execution>
-						<id>sign-artifacts</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>sign</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>				
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>
 				<version>1.3.1</version>
 				<executions>

--- a/src/main/java/com/github/jcrfsuite/util/CrfSuiteLoader.java
+++ b/src/main/java/com/github/jcrfsuite/util/CrfSuiteLoader.java
@@ -111,9 +111,11 @@ public class CrfSuiteLoader {
 	  
     private static ClassLoader getRootClassLoader() {
         ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        /* We want to keep the tacokit classloader
         while (cl.getParent() != null) {
             cl = cl.getParent();
         }
+        */
         return cl;
     }
 


### PR DESCRIPTION
The current implementation of JCRFSuite try to integrate the C dependencies on the root classloader.

The tacokit classloader do not support transitive dependencies from its parent classloader.
As a result, the C dependencies will not be loaded on the tacokit classloader.

The new implement add the C dependencies inside the current classloader, which may not works on many project, but will allows us to use the library.
